### PR TITLE
Make benchmarks measure OpenCL time

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -15,4 +15,4 @@ main = do
   -- We need to ensure that this is not counted in the benchmark
   let !c = BS.toStrict $ fromRight (error "Could not compile") $ compile code
   let !d = BS.fromStrict c
-  defaultMain [bgroup "sort" [bench "test" $ nfIO $ runCompiled d]]
+  defaultMain [bgroup "sort" [bench "test" $ nfIO $ runCompiled d >>= (\x -> return (head . head <$> x))]]

--- a/src/Code/Definitions.hs
+++ b/src/Code/Definitions.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+
 module Code.Definitions
   ( GPUBufferName (..),
     GPUBuffer (..),

--- a/src/CodeGen/OpenCL.hs
+++ b/src/CodeGen/OpenCL.hs
@@ -1,7 +1,76 @@
-module CodeGen.OpenCL (mkOpenCLKernelCode) where
+module CodeGen.OpenCL
+  ( mkOpenCLKernelCode,
+    runOpenCL,
+    runOpenCLCompiled,
+    runOpenCLWithConv,
+    runOpenCLCompiledWithConv,
+  )
+where
 
+import Code
+import Code.Definitions as C
+import Code.SCode
 import CodeGen.CLike
+import qualified Data.ByteString.Lazy as BS
+import Foreign
+import Foreign.C
 import Language.GaiwanDefs
+import OpenCL
 
 mkOpenCLKernelCode a@(PipedExp expressions) = mkCodeB a
-mkOpenCLKernelCode a = mkCode a
+
+runOpenCL :: Code String -> IO [[Integer]]
+runOpenCL c = uncurry runToList (compile c)
+
+runOpenCLWithConv c s =
+  maybe
+    (return Nothing)
+    (fmap Just . uncurry (runToListWithConvertor c))
+    $ deserialize s
+
+runOpenCLCompiled :: BS.ByteString -> IO (Maybe [[Integer]])
+runOpenCLCompiled = runOpenCLCompiledWithConv cnftr
+
+runOpenCLCompiledWithConv :: (Int -> Ptr CInt -> IO a) -> BS.ByteString -> IO (Maybe [a])
+runOpenCLCompiledWithConv c s =
+  maybe
+    (return Nothing)
+    (fmap Just . uncurry (runToListWithConvertor c))
+    $ deserialize s
+
+runToListWithConvertor :: (Int -> Ptr CInt -> IO a) -> String -> [GPUAction] -> IO [a]
+runToListWithConvertor c devCode hostCode = do
+  runner <- mkOpenRunner c devCode
+  run runner $ toOpenCL hostCode
+
+runToList :: String -> [GPUAction] -> IO [[Integer]]
+runToList = runToListWithConvertor cnftr
+
+-- | Convertor function from a malloed buffer to output,
+--
+-- Here, we take the numbers and convert them to ingegers
+cnftr :: Int -> Ptr CInt -> IO [Integer]
+cnftr size ptr = map toInteger <$> peekArray size ptr
+
+toOpenCL :: [GPUAction] -> [OpenCLAction]
+toOpenCL actions = addFrees $ map toOpenCLAction actions
+
+-- | Convert a GPUBuffer to and OpenCLBuffer
+toOpenCLBuf (GPUBuffer (GPUBufferName i) size) = CLGPUBuffer i size
+
+-- | Convet actions tot OpenCL actions
+toOpenCLAction :: GPUAction -> OpenCLAction
+toOpenCLAction (CallKernel (KernelName n) args _ threads) = MakeKernel n (map toOpenCLBuf args) (Range threads 0 0)
+toOpenCLAction (C.ReadBuffer x) = OpenCL.ReadBuffer (toOpenCLBuf x)
+toOpenCLAction (C.AllocBuffer b) = OpenCL.AllocBuffer $ toOpenCLBuf b
+
+-- | Add a FreeBuffer for every AllocBuffer action
+addFrees l =
+  l
+    ++ foldr
+      ( \new a -> case new of
+          OpenCL.AllocBuffer x -> OpenCL.FreeBuffer x : a
+          _ -> a
+      )
+      []
+      l

--- a/src/CodeGen/Render.hs
+++ b/src/CodeGen/Render.hs
@@ -115,7 +115,7 @@ mkKernel name kernelBuffers outBuffers code = [(name, _mkKernel)]
 render :: Program -> Pic
 render (Prog defines prog) = Pic foldProg
   where
-    (kernels, actions) = compileUnopt . execCode $ do
+    (kernels, actions) = compile . execCode $ do
       mapM_ registerDef defines
       mkCode prog
     foldProg :: [PicLevel]

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -52,10 +52,12 @@ mkCode (Prog defines main) =
 
 convert :: Program -> IO [[Integer]]
 convert program =
-  runCodeToList $ mkCode program
+  runOpenCL $ mkCode program
 
 render :: String -> Either String BS.ByteString
 render =
   eitherParseGaiwan
     (\err -> Left $ "Parsing failed: " ++ err)
     (Right . Render.renderJSON)
+
+runCompiled = runOpenCLCompiled

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -1,6 +1,5 @@
 module Render
-  ( render,
-    renderJSON,
+  ( renderJSON,
   )
 where
 

--- a/test/RenderSpec.hs
+++ b/test/RenderSpec.hs
@@ -2,6 +2,7 @@
 
 module RenderSpec (spec) where
 
+import CodeGen.Render
 import qualified Data.ByteString.Lazy as BS
 import Language.Gaiwan
 import Language.GaiwanDefs


### PR DESCRIPTION
At the moment benchmarks are measuring all kinds of extra time that are not relevant, such as converting the output buffer to a cons list. This PR fixers that